### PR TITLE
Enable WebGL backend for pose estimation

### DIFF
--- a/src/components/PushupTracker.tsx
+++ b/src/components/PushupTracker.tsx
@@ -8,6 +8,7 @@ import { Play, Pause, Square, Camera, CameraOff, ZoomIn, ZoomOut, Eye, EyeOff } 
 import { useToast } from '@/hooks/use-toast';
 import { Session } from '@/pages/Index';
 import * as tf from '@tensorflow/tfjs';
+import '@tensorflow/tfjs-backend-webgl';
 import * as poseDetection from '@tensorflow-models/pose-detection';
 
 // Enhanced PushupDetector with TensorFlow.js PoseNet
@@ -29,6 +30,7 @@ class PushupDetector {
   private async initializePose() {
     try {
       console.log('Initializing TensorFlow.js backend...');
+      await tf.setBackend('webgl');
       await tf.ready();
       
       console.log('Creating pose detector...');


### PR DESCRIPTION
## Summary
- enable TensorFlow.js WebGL backend before initializing pose detector
- import WebGL backend module

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840276edc94832dbdae350f21145b86