### PR TITLE
Fix repeated ROI width errors

### DIFF
--- a/src/components/PushupTracker.tsx
+++ b/src/components/PushupTracker.tsx
@@ -74,6 +74,10 @@ class PushupDetector {
         }
       } catch (error) {
         console.error('Pose detection error:', error);
+        if ((error as Error).message && (error as Error).message.includes('roi width cannot be 0')) {
+          console.warn('Reinitializing pose detector due to ROI error');
+          await this.initializePose();
+        }
       }
     }
     return this.count;


### PR DESCRIPTION
## Summary
- reinitialize pose detector when ROI width error occurs

## Testing
- `npm run lint` *(fails: Unexpected any rules, etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68402ac6be28832dbda80b316e5a314e