### PR TITLE
Improve PoseNet error handling

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -92,5 +93,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- dispose old detector before re-initializing PoseNet
- skip frames that cause ROI errors instead of re-initializing
- flip pose detection horizontally to match mirrored video
- load tailwindcss-animate using `import`

## Testing
- `npm run lint` *(fails: 24 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6840303ef1e4832d95047af7548a2b67