### PR TITLE
Fix drawing utils import

### DIFF
--- a/src/components/PushupTracker.tsx
+++ b/src/components/PushupTracker.tsx
@@ -20,7 +20,8 @@ import { useToast } from '@/hooks/use-toast';
 import { Session } from '@/pages/Index';
 
 import { POSE_CONNECTIONS, Results as PoseResults } from '@mediapipe/pose';
-import { drawConnectors, drawLandmarks } from '@mediapipe/drawing_utils';
+import drawingUtils from '@mediapipe/drawing_utils';
+const { drawConnectors, drawLandmarks } = drawingUtils;
 import {
   PushupDetector,
   POSE_LANDMARK_NAMES,


### PR DESCRIPTION
## Summary
- update PushupTracker to import `@mediapipe/drawing_utils` via default export
- destructure `drawConnectors` and `drawLandmarks` from the module

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68420f2f6f5c832d99fa645a6039d525