### PR TITLE
Fix drawing utils import

### DIFF
--- a/src/components/PushupTracker.tsx
+++ b/src/components/PushupTracker.tsx
@@ -20,7 +20,8 @@ import { useToast } from '@/hooks/use-toast';
 import { Session } from '@/pages/Index';
 
 import type { Results as PoseResults, NormalizedLandmark, NormalizedLandmarkList } from '@mediapipe/pose';
-import { drawConnectors, drawLandmarks } from '@mediapipe/drawing_utils';
+import drawingUtils from '@mediapipe/drawing_utils/drawing_utils.js';
+const { drawConnectors, drawLandmarks } = drawingUtils;
 import { POSE_CONNECTIONS } from '@/lib/poseConstants';
 import {
   PushupDetector,

--- a/src/types/mediapipe.d.ts
+++ b/src/types/mediapipe.d.ts
@@ -1,0 +1,11 @@
+declare module '@mediapipe/drawing_utils/drawing_utils.js' {
+  export * from '@mediapipe/drawing_utils';
+  const drawingUtils: {
+    drawConnectors: typeof import('@mediapipe/drawing_utils').drawConnectors;
+    drawLandmarks: typeof import('@mediapipe/drawing_utils').drawLandmarks;
+    drawRectangle: typeof import('@mediapipe/drawing_utils').drawRectangle;
+    clamp: typeof import('@mediapipe/drawing_utils').clamp;
+    lerp: typeof import('@mediapipe/drawing_utils').lerp;
+  };
+  export default drawingUtils;
+}


### PR DESCRIPTION
## Summary
- fix imports of drawing_utils
- declare module for mediapipe drawing utils

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68427ff367b0832d95025638fed1b9f2