### PR TITLE
Allow usernames in community sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ small. Connection pairs are defined locally in
 ### Nutzung von Supabase
 
 Alternativ können Sie die mitgelieferte Supabase‑Integration verwenden. Legen
-einfach eine Tabelle `sessions` mit den Spalten `email`, `date` und `count` in
+einfach eine Tabelle `sessions` mit den Spalten `email`, `username`, `date` und `count` in
 Ihrem Supabase-Projekt an. Hinterlegen Sie anschließend Ihre Supabase URL und
 den Anon Key in einer Datei `.env` im Projektwurzelverzeichnis:
 
@@ -74,6 +74,8 @@ NEXT_PUBLIC_SUPABASE_URL=<your-url>
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-key>
 ```
 Kopiere die Datei `.env.example` zu `.env` und fülle sie mit deinen Daten. Danach `npm run dev` oder `npm run build` ausführen.
+
+Bei der Registrierung kannst du optional einen Benutzernamen angeben. Dieser wird zusammen mit deinen Sessions gespeichert und in den Community-Highscores angezeigt.
 
 Dank der Einstellung `envPrefix` in `vite.config.ts` werden sowohl `VITE_` als
 auch `NEXT_PUBLIC_` Variablen automatisch vom Build übernommen.

--- a/src/components/Community.tsx
+++ b/src/components/Community.tsx
@@ -8,12 +8,13 @@ import { Users } from 'lucide-react';
 interface CommunityProps {
   email: string | null;
   token: string | null;
-  onAuth: (email: string, token: string) => void;
+  onAuth: (email: string, token: string, username?: string) => void;
 }
 
 export const Community: React.FC<CommunityProps> = ({ email, token: propToken, onAuth }) => {
   const [regEmail, setRegEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [username, setUsername] = useState('');
   const [token, setToken] = useState<string | null>(propToken);
   const [daily, setDaily] = useState<ScoreEntry[]>([]);
   const [weekly, setWeekly] = useState<ScoreEntry[]>([]);
@@ -46,6 +47,11 @@ export const Community: React.FC<CommunityProps> = ({ email, token: propToken, o
             placeholder="E-Mail"
           />
           <Input
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="Benutzername (optional)"
+          />
+          <Input
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
@@ -57,9 +63,9 @@ export const Community: React.FC<CommunityProps> = ({ email, token: propToken, o
               onClick={async () => {
                 if (regEmail && password) {
                   try {
-                    const t = await register(regEmail, password);
+                    const t = await register(regEmail, password, username);
                     setToken(t);
-                    onAuth(regEmail, t);
+                    onAuth(regEmail, t, username);
                     setError(null);
                   } catch (e) {
                     setError((e as Error).message);
@@ -75,7 +81,7 @@ export const Community: React.FC<CommunityProps> = ({ email, token: propToken, o
                   try {
                     const t = await login(regEmail, password);
                     setToken(t);
-                    onAuth(regEmail, t);
+                    onAuth(regEmail, t, username);
                     setError(null);
                   } catch (e) {
                     setError((e as Error).message);
@@ -99,9 +105,9 @@ export const Community: React.FC<CommunityProps> = ({ email, token: propToken, o
       ) : (
         <div className="space-y-1">
           {scores.map((s, i) => (
-            <div key={s.email} className="flex justify-between">
+            <div key={s.name} className="flex justify-between">
               <span>
-                {i + 1}. {s.email}
+                {i + 1}. {s.name}
               </span>
               <span>{s.count}</span>
             </div>

--- a/src/lib/community.ts
+++ b/src/lib/community.ts
@@ -1,5 +1,6 @@
 export interface CommunitySession {
   email: string;
+  username?: string;
   date: string; // ISO string
   count: number;
 }
@@ -7,7 +8,7 @@ export interface CommunitySession {
 const STORAGE_KEY = 'communitySessions';
 
 export interface ScoreEntry {
-  email: string;
+  name: string;
   count: number;
 }
 
@@ -30,8 +31,16 @@ import { supabase } from './supabaseClient';
 
 // --- Server API (via Supabase) ---
 
-export async function register(email: string, password: string): Promise<string> {
-  const { data, error } = await supabase.auth.signUp({ email, password });
+export async function register(
+  email: string,
+  password: string,
+  username?: string,
+): Promise<string> {
+  const { data, error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: { data: { username } },
+  });
   if (error || !data.session) {
     throw new Error('Registrierung fehlgeschlagen');
   }
@@ -46,17 +55,22 @@ export async function login(email: string, password: string): Promise<string> {
   return data.session.access_token;
 }
 
-export async function saveSessionServer(token: string, session: Omit<CommunitySession, 'email'>) {
+export async function saveSessionServer(
+  token: string,
+  session: Omit<CommunitySession, 'email' | 'username'>,
+) {
   // ensure current session
   const current = await supabase.auth.getSession();
   if (!current.data.session) throw new Error('Nicht eingeloggt');
 
   const { data: userData } = await supabase.auth.getUser();
   const email = userData.user?.email;
+  const username = (userData.user?.user_metadata as { username?: string })?.username;
   if (!email) throw new Error('Kein Benutzer gefunden');
 
   await supabase.from('sessions').insert({
     email,
+    username,
     date: session.date,
     count: session.count,
   });
@@ -78,17 +92,18 @@ export async function fetchHighscores(period: 'day' | 'week' | 'month'): Promise
 
   const { data, error } = await supabase
     .from('sessions')
-    .select('email, count, date')
+    .select('email, username, count, date')
     .gte('date', start.toISOString());
   if (error) throw new Error('Fehler beim Laden der Highscores');
 
   const totals: Record<string, number> = {};
   (data || []).forEach(r => {
-    totals[r.email as string] = (totals[r.email as string] || 0) + (r.count as number);
+    const name = (r.username as string) || (r.email as string);
+    totals[name] = (totals[name] || 0) + (r.count as number);
   });
 
   return Object.entries(totals)
-    .map(([email, count]) => ({ email, count }))
+    .map(([name, count]) => ({ name, count }))
     .sort((a, b) => b.count - a.count)
     .slice(0, 10);
 }
@@ -112,12 +127,13 @@ export function computeHighscores(period: 'day' | 'week' | 'month'): ScoreEntry[
   sessions.forEach(s => {
     const d = new Date(s.date);
     if (d >= start) {
-      totals[s.email] = (totals[s.email] || 0) + s.count;
+      const name = s.username || s.email;
+      totals[name] = (totals[name] || 0) + s.count;
     }
   });
 
   return Object.entries(totals)
-    .map(([email, count]) => ({ email, count }))
+    .map(([name, count]) => ({ name, count }))
     .sort((a, b) => b.count - a.count)
     .slice(0, 10);
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -30,12 +30,15 @@ const Index: React.FC<IndexProps> = ({ user }) => {
   const [isTracking, setIsTracking] = useState(false);
   const [communityEmail, setCommunityEmail] = useState<string | null>(null);
   const [communityToken, setCommunityToken] = useState<string | null>(null);
+  const [communityUsername, setCommunityUsername] = useState<string | null>(null);
 
   useEffect(() => {
     const storedEmail = localStorage.getItem('communityEmail');
     const storedToken = localStorage.getItem('communityToken');
+    const storedUsername = localStorage.getItem('communityUsername');
     if (storedEmail) setCommunityEmail(storedEmail);
     if (storedToken) setCommunityToken(storedToken);
+    if (storedUsername) setCommunityUsername(storedUsername);
   }, []);
 
   useEffect(() => {
@@ -67,9 +70,13 @@ const Index: React.FC<IndexProps> = ({ user }) => {
     load();
   }, [user?.id]);
 
-  const handleRegister = (email: string, token: string) => {
+  const handleRegister = (email: string, token: string, username?: string) => {
     setCommunityEmail(email);
     setCommunityToken(token);
+    if (username) {
+      setCommunityUsername(username);
+      localStorage.setItem('communityUsername', username);
+    }
     localStorage.setItem('communityEmail', email);
     localStorage.setItem('communityToken', token);
   };
@@ -102,6 +109,7 @@ const Index: React.FC<IndexProps> = ({ user }) => {
     } else if (communityEmail) {
       saveCommunitySession({
         email: communityEmail,
+        username: communityUsername || undefined,
         date: new Date().toISOString(),
         count: newSession.count,
       });


### PR DESCRIPTION
## Summary
- support optional username field for community sessions
- show username field in community login
- store username in local storage and Supabase
- update README instructions

## Testing
- `npm run build:dev`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6842cde76ac0832daf667952a4631be1