### PR TITLE
Require username on registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ Bei der Registrierung musst du einen Benutzernamen angeben. Dieser wird zusammen
 mit deinen Sessions gespeichert und in den Community-Highscores angezeigt.
 Du meldest dich danach mit deiner E-Mail-Adresse und deinem Passwort an.
 Jede E-Mail-Adresse ist genau einem Benutzernamen zugeordnet.
+Die Highscores im "Community"-Tab kannst du auch ohne Login einsehen. Darunter
+findest du zwei getrennte Formulare: eines zum Einloggen (E-Mail und Passwort)
+und eines zur Registrierung (Benutzername, E-Mail und Passwort).
 
 Dank der Einstellung `envPrefix` in `vite.config.ts` werden sowohl `VITE_` als
 auch `NEXT_PUBLIC_` Variablen automatisch vom Build übernommen.
@@ -96,8 +99,8 @@ auch `NEXT_PUBLIC_` Variablen automatisch vom Build übernommen.
 
 Nach `npm run dev` oder `npm run build` wird Supabase für Registrierung, Login
 und Highscore-Abfragen verwendet. Melde dich im "Community"-Tab an, damit deine
-Sessions gespeichert werden und du die Highscores sehen kannst. Stelle sicher,
-dass die Tabelle `sessions` öffentlich lesbar ist oder passende
+Sessions gespeichert werden. Die Highscores sind auch ohne Login sichtbar.
+Stelle sicher, dass die Tabelle `sessions` öffentlich lesbar ist oder passende
 Row-Level-Security-Regeln eingerichtet sind.
 
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-key>
 ```
 Kopiere die Datei `.env.example` zu `.env` und fülle sie mit deinen Daten. Danach `npm run dev` oder `npm run build` ausführen.
 
-Bei der Registrierung musst du einen Benutzernamen angeben. Dieser wird zusammen mit deinen Sessions gespeichert und in den Community-Highscores angezeigt.
+Bei der Registrierung musst du einen Benutzernamen angeben. Dieser wird zusammen
+mit deinen Sessions gespeichert und in den Community-Highscores angezeigt.
+Du meldest dich danach mit deiner E-Mail-Adresse und deinem Passwort an.
+Jede E-Mail-Adresse ist genau einem Benutzernamen zugeordnet.
 
 Dank der Einstellung `envPrefix` in `vite.config.ts` werden sowohl `VITE_` als
 auch `NEXT_PUBLIC_` Variablen automatisch vom Build übernommen.

--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -6,14 +6,24 @@ import { Button } from '@/components/ui/button';
 export default function AuthForm({ onAuth }: { onAuth: () => void }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [username, setUsername] = useState('');
   const [isLogin, setIsLogin] = useState(true);
   const [error, setError] = useState('');
 
   const handleSubmit = async () => {
     setError('');
+    if (!email || !password || (!isLogin && !username)) {
+      setError('Bitte alle Felder ausfüllen');
+      return;
+    }
+
     const { error } = isLogin
       ? await supabase.auth.signInWithPassword({ email, password })
-      : await supabase.auth.signUp({ email, password });
+      : await supabase.auth.signUp({
+          email,
+          password,
+          options: { data: { username } },
+        });
 
     if (error) setError(error.message);
     else onAuth();
@@ -22,11 +32,30 @@ export default function AuthForm({ onAuth }: { onAuth: () => void }) {
   return (
     <div className="space-y-4 max-w-sm mx-auto mt-20 p-6 bg-white rounded shadow">
       <Input placeholder="E-Mail" value={email} onChange={e => setEmail(e.target.value)} />
-      <Input type="password" placeholder="Passwort" value={password} onChange={e => setPassword(e.target.value)} />
+      {!isLogin && (
+        <Input
+          placeholder="Benutzername"
+          value={username}
+          onChange={e => setUsername(e.target.value)}
+        />
+      )}
+      <Input
+        type="password"
+        placeholder="Passwort"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+      />
       <Button onClick={handleSubmit} className="w-full">
         {isLogin ? 'Einloggen' : 'Registrieren'}
       </Button>
-      <button onClick={() => setIsLogin(!isLogin)} className="text-sm underline">
+      <button
+        onClick={() => {
+          setIsLogin(!isLogin);
+          setError('');
+          setUsername('');
+        }}
+        className="text-sm underline"
+      >
         {isLogin ? 'Noch kein Konto? Registrieren' : 'Bereits registriert? Login'}
       </button>
       {error && <div className="text-red-500 text-sm">{error}</div>}

--- a/src/components/Community.tsx
+++ b/src/components/Community.tsx
@@ -13,9 +13,11 @@ interface CommunityProps {
 }
 
 export const Community: React.FC<CommunityProps> = ({ email, token: propToken, onAuth }) => {
+  const [loginEmail, setLoginEmail] = useState('');
+  const [loginPassword, setLoginPassword] = useState('');
   const [regEmail, setRegEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [username, setUsername] = useState('');
+  const [regPassword, setRegPassword] = useState('');
+  const [regUsername, setRegUsername] = useState('');
   const [token, setToken] = useState<string | null>(propToken);
   const [daily, setDaily] = useState<ScoreEntry[]>([]);
   const [weekly, setWeekly] = useState<ScoreEntry[]>([]);
@@ -27,83 +29,10 @@ export const Community: React.FC<CommunityProps> = ({ email, token: propToken, o
   }, [propToken]);
 
   useEffect(() => {
-    if (token) {
-      fetchHighscores('day').then(setDaily);
-      fetchHighscores('week').then(setWeekly);
-      fetchHighscores('month').then(setMonthly);
-    }
+    fetchHighscores('day').then(setDaily);
+    fetchHighscores('week').then(setWeekly);
+    fetchHighscores('month').then(setMonthly);
   }, [token]);
-
-  if (!token) {
-    return (
-      <Card className="p-6 space-y-4">
-        <div className="flex items-center gap-2">
-          <Users className="h-5 w-5" />
-          <h3 className="text-lg font-semibold">Community Login</h3>
-        </div>
-        <div className="flex flex-col gap-2">
-          <Input
-            value={regEmail}
-            onChange={(e) => setRegEmail(e.target.value)}
-            placeholder="E-Mail"
-          />
-          <Input
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            placeholder="Benutzername"
-          />
-          <Input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            placeholder="Passwort"
-          />
-          {error && <p className="text-red-600 text-sm">{error}</p>}
-          <div className="flex gap-2">
-            <Button
-              onClick={async () => {
-                if (regEmail && password && username) {
-                  try {
-                    const t = await register(regEmail, password, username);
-                    setToken(t);
-                    onAuth(regEmail, t, username);
-                    setError(null);
-                  } catch (e) {
-                    setError((e as Error).message);
-                  }
-                } else {
-                  setError('Bitte E-Mail, Passwort und Benutzernamen eingeben');
-                }
-              }}
-            >
-              Registrieren
-            </Button>
-            <Button
-              onClick={async () => {
-                if (regEmail && password) {
-                  try {
-                    const t = await login(regEmail, password);
-                    const { data } = await supabase.auth.getUser();
-                    const uname =
-                      (data.user?.user_metadata as { username?: string })?.username || '';
-                    setToken(t);
-                    onAuth(regEmail, t, uname);
-                    setError(null);
-                  } catch (e) {
-                    setError((e as Error).message);
-                  }
-                } else {
-                  setError('Bitte E-Mail und Passwort eingeben');
-                }
-              }}
-            >
-              Login
-            </Button>
-          </div>
-        </div>
-      </Card>
-    );
-  }
 
   const renderTable = (title: string, scores: ScoreEntry[]) => (
     <Card className="p-6">
@@ -130,6 +59,89 @@ export const Community: React.FC<CommunityProps> = ({ email, token: propToken, o
       {renderTable('Tages-Highscore', daily)}
       {renderTable('Wochen-Highscore', weekly)}
       {renderTable('Monats-Highscore', monthly)}
+      {!token && (
+        <Card className="p-6 space-y-4">
+          <div className="flex items-center gap-2">
+            <Users className="h-5 w-5" />
+            <h3 className="text-lg font-semibold">Community Login</h3>
+          </div>
+          {error && <p className="text-red-600 text-sm">{error}</p>}
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="flex flex-col gap-2">
+              <h4 className="font-medium">Login</h4>
+              <Input
+                value={loginEmail}
+                onChange={e => setLoginEmail(e.target.value)}
+                placeholder="E-Mail"
+              />
+              <Input
+                type="password"
+                value={loginPassword}
+                onChange={e => setLoginPassword(e.target.value)}
+                placeholder="Passwort"
+              />
+              <Button
+                onClick={async () => {
+                  if (loginEmail && loginPassword) {
+                    try {
+                      const t = await login(loginEmail, loginPassword);
+                      const { data } = await supabase.auth.getUser();
+                      const uname =
+                        (data.user?.user_metadata as { username?: string })?.username || '';
+                      setToken(t);
+                      onAuth(loginEmail, t, uname);
+                      setError(null);
+                    } catch (e) {
+                      setError((e as Error).message);
+                    }
+                  } else {
+                    setError('Bitte E-Mail und Passwort eingeben');
+                  }
+                }}
+              >
+                Login
+              </Button>
+            </div>
+            <div className="flex flex-col gap-2">
+              <h4 className="font-medium">Registrieren</h4>
+              <Input
+                value={regUsername}
+                onChange={e => setRegUsername(e.target.value)}
+                placeholder="Benutzername"
+              />
+              <Input
+                value={regEmail}
+                onChange={e => setRegEmail(e.target.value)}
+                placeholder="E-Mail"
+              />
+              <Input
+                type="password"
+                value={regPassword}
+                onChange={e => setRegPassword(e.target.value)}
+                placeholder="Passwort"
+              />
+              <Button
+                onClick={async () => {
+                  if (regEmail && regPassword && regUsername) {
+                    try {
+                      const t = await register(regEmail, regPassword, regUsername);
+                      setToken(t);
+                      onAuth(regEmail, t, regUsername);
+                      setError(null);
+                    } catch (e) {
+                      setError((e as Error).message);
+                    }
+                  } else {
+                    setError('Bitte alle Felder ausfüllen');
+                  }
+                }}
+              >
+                Registrieren
+              </Button>
+            </div>
+          </div>
+        </Card>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- ask for username when signing up
- record username metadata on registration
- document email+username relationship
- fix highscore aggregation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684317b5781c832dacec5db9819627b2