### PR TITLE
Show total counts on highscore tables

### DIFF
--- a/src/components/Community.tsx
+++ b/src/components/Community.tsx
@@ -2,7 +2,13 @@ import React, { useEffect, useState } from 'react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { fetchHighscores, register, login, ScoreEntry } from '@/lib/community';
+import {
+  fetchHighscores,
+  register,
+  login,
+  ScoreEntry,
+  HighscoreResult,
+} from '@/lib/community';
 import { supabase } from '@/lib/supabaseClient';
 import { Users } from 'lucide-react';
 
@@ -22,6 +28,9 @@ export const Community: React.FC<CommunityProps> = ({ email, token: propToken, o
   const [daily, setDaily] = useState<ScoreEntry[]>([]);
   const [weekly, setWeekly] = useState<ScoreEntry[]>([]);
   const [monthly, setMonthly] = useState<ScoreEntry[]>([]);
+  const [dailyTotal, setDailyTotal] = useState(0);
+  const [weeklyTotal, setWeeklyTotal] = useState(0);
+  const [monthlyTotal, setMonthlyTotal] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -29,36 +38,48 @@ export const Community: React.FC<CommunityProps> = ({ email, token: propToken, o
   }, [propToken]);
 
   useEffect(() => {
-    fetchHighscores('day').then(setDaily);
-    fetchHighscores('week').then(setWeekly);
-    fetchHighscores('month').then(setMonthly);
+    fetchHighscores('day').then((res) => {
+      setDaily(res.scores);
+      setDailyTotal(res.total);
+    });
+    fetchHighscores('week').then((res) => {
+      setWeekly(res.scores);
+      setWeeklyTotal(res.total);
+    });
+    fetchHighscores('month').then((res) => {
+      setMonthly(res.scores);
+      setMonthlyTotal(res.total);
+    });
   }, [token]);
 
-  const renderTable = (title: string, scores: ScoreEntry[]) => (
+  const renderTable = (title: string, scores: ScoreEntry[], total: number) => (
     <Card className="p-6">
       <h3 className="text-lg font-semibold mb-4">{title}</h3>
       {scores.length === 0 ? (
         <p className="text-gray-500">Noch keine Daten</p>
       ) : (
-        <div className="space-y-1">
-          {scores.map((s, i) => (
-            <div key={s.name} className="flex justify-between">
-              <span>
-                {i + 1}. {s.name}
-              </span>
-              <span>{s.count}</span>
-            </div>
-          ))}
-        </div>
+        <>
+          <div className="space-y-1 mb-2">
+            {scores.map((s, i) => (
+              <div key={s.name} className="flex justify-between">
+                <span>
+                  {i + 1}. {s.name}
+                </span>
+                <span>{s.count}</span>
+              </div>
+            ))}
+          </div>
+          <div className="text-right font-semibold">Summe: {total}</div>
+        </>
       )}
     </Card>
   );
 
   return (
     <div className="space-y-4">
-      {renderTable('Tages-Highscore', daily)}
-      {renderTable('Wochen-Highscore', weekly)}
-      {renderTable('Monats-Highscore', monthly)}
+      {renderTable('Tages-Highscore', daily, dailyTotal)}
+      {renderTable('Wochen-Highscore', weekly, weeklyTotal)}
+      {renderTable('Monats-Highscore', monthly, monthlyTotal)}
       {!token && (
         <Card className="p-6 space-y-4">
           <div className="flex items-center gap-2">

--- a/src/lib/community.ts
+++ b/src/lib/community.ts
@@ -12,6 +12,11 @@ export interface ScoreEntry {
   count: number;
 }
 
+export interface HighscoreResult {
+  scores: ScoreEntry[];
+  total: number;
+}
+
 export function loadCommunitySessions(): CommunitySession[] {
   if (typeof localStorage === 'undefined') return [];
   try {
@@ -139,7 +144,7 @@ export async function saveSessionServer(
     });
 }
 
-export async function fetchHighscores(period: 'day' | 'week' | 'month'): Promise<ScoreEntry[]> {
+export async function fetchHighscores(period: 'day' | 'week' | 'month'): Promise<HighscoreResult> {
   const now = new Date();
   let start: Date;
   if (period === 'day') {
@@ -204,21 +209,25 @@ export async function fetchHighscores(period: 'day' | 'week' | 'month'): Promise
   if (error) throw new Error('Fehler beim Laden der Highscores');
 
   const totals = new Map<string, { name: string; count: number }>();
+  let totalCount = 0;
   (data || []).forEach(r => {
     const rawName = (r.username as string) || (r.email as string);
     const key = rawName?.trim().toLowerCase();
     if (!key) return;
+    totalCount += r.count as number;
     const existing = totals.get(key);
     if (existing) existing.count += r.count as number;
     else totals.set(key, { name: rawName.trim(), count: r.count as number });
   });
 
-  return Array.from(totals.values())
+  const scores = Array.from(totals.values())
     .sort((a, b) => b.count - a.count)
     .slice(0, 10);
+
+  return { scores, total: totalCount };
 }
 
-export function computeHighscores(period: 'day' | 'week' | 'month'): ScoreEntry[] {
+export function computeHighscores(period: 'day' | 'week' | 'month'): HighscoreResult {
   const sessions = loadCommunitySessions();
   const now = new Date();
   let start: Date;
@@ -234,19 +243,23 @@ export function computeHighscores(period: 'day' | 'week' | 'month'): ScoreEntry[
   }
 
   const totals = new Map<string, { name: string; count: number }>();
+  let totalCount = 0;
   sessions.forEach(s => {
     const d = new Date(s.date);
     if (d >= start) {
       const rawName = s.username || s.email;
       const key = rawName?.trim().toLowerCase();
       if (!key) return;
+      totalCount += s.count;
       const existing = totals.get(key);
       if (existing) existing.count += s.count;
       else totals.set(key, { name: rawName.trim(), count: s.count });
     }
   });
 
-  return Array.from(totals.values())
+  const scores = Array.from(totals.values())
     .sort((a, b) => b.count - a.count)
     .slice(0, 10);
+
+  return { scores, total: totalCount };
 }


### PR DESCRIPTION
## Summary
- support returning totals when loading highscores
- display daily/weekly/monthly push-up totals in the community highscores

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684326916100832d99bc1f4359d3438e