### PR TITLE
Add squat detection and stats

### DIFF
--- a/src/components/Community.tsx
+++ b/src/components/Community.tsx
@@ -17,9 +17,10 @@ interface CommunityProps {
   token: string | null;
   onAuth: (email: string, token: string, username: string) => void;
   refreshTrigger: number;
+  exercise: 'pushup' | 'squat';
 }
 
-export const Community: React.FC<CommunityProps> = ({ email, token: propToken, onAuth, refreshTrigger }) => {
+export const Community: React.FC<CommunityProps> = ({ email, token: propToken, onAuth, refreshTrigger, exercise }) => {
   const [loginEmail, setLoginEmail] = useState('');
   const [loginPassword, setLoginPassword] = useState('');
   const [regEmail, setRegEmail] = useState('');
@@ -39,19 +40,19 @@ export const Community: React.FC<CommunityProps> = ({ email, token: propToken, o
   }, [propToken]);
 
   useEffect(() => {
-    fetchHighscores('day').then((res) => {
+    fetchHighscores('day', exercise).then((res) => {
       setDaily(res.scores);
       setDailyTotal(res.total);
     });
-    fetchHighscores('week').then((res) => {
+    fetchHighscores('week', exercise).then((res) => {
       setWeekly(res.scores);
       setWeeklyTotal(res.total);
     });
-    fetchHighscores('month').then((res) => {
+    fetchHighscores('month', exercise).then((res) => {
       setMonthly(res.scores);
       setMonthlyTotal(res.total);
     });
-  }, [token, refreshTrigger]);
+  }, [token, refreshTrigger, exercise]);
 
   const renderTable = (title: string, scores: ScoreEntry[], total: number) => (
     <Card className="p-6">

--- a/src/components/SessionHistory.tsx
+++ b/src/components/SessionHistory.tsx
@@ -60,7 +60,7 @@ export const SessionHistory: React.FC<SessionHistoryProps> = ({ sessions }) => {
             <Trophy className="h-6 w-6" />
             <div>
               <p className="text-green-100 text-sm">Beste Session</p>
-              <p className="text-xl font-bold">{bestSession} Liegestützen</p>
+              <p className="text-xl font-bold">{bestSession} Wiederholungen</p>
             </div>
           </div>
         </Card>
@@ -101,7 +101,10 @@ export const SessionHistory: React.FC<SessionHistoryProps> = ({ sessions }) => {
                   {/* Session Details */}
                   <div className="flex-grow">
                     <div className="flex items-center gap-3 mb-1">
-                      <h3 className="text-lg font-semibold">{session.count} Liegestützen</h3>
+                      <h3 className="text-lg font-semibold">
+                        {session.count}{' '}
+                        {session.exercise === 'pushup' ? 'Liegestützen' : 'Kniebeugen'}
+                      </h3>
                       {isPersonalRecord && (
                         <Badge className="bg-yellow-500 hover:bg-yellow-600">
                           <Trophy className="h-3 w-3 mr-1" />

--- a/src/components/StatsDisplay.tsx
+++ b/src/components/StatsDisplay.tsx
@@ -8,9 +8,10 @@ import { TrendingUp, Clock, Zap, Target } from 'lucide-react';
 
 interface StatsDisplayProps {
   sessions: Session[];
+  exercise: 'pushup' | 'squat';
 }
 
-export const StatsDisplay: React.FC<StatsDisplayProps> = ({ sessions }) => {
+export const StatsDisplay: React.FC<StatsDisplayProps> = ({ sessions, exercise }) => {
   if (sessions.length === 0) {
     return (
       <Card className="p-8">
@@ -23,15 +24,17 @@ export const StatsDisplay: React.FC<StatsDisplayProps> = ({ sessions }) => {
     );
   }
 
+  const filtered = sessions.filter(s => s.exercise === exercise);
+
   // Calculate statistics
-  const totalPushups = sessions.reduce((sum, session) => sum + session.count, 0);
-  const totalTime = sessions.reduce((sum, session) => sum + session.duration, 0);
-  const avgPerSession = Math.round(totalPushups / sessions.length);
-  const bestSession = Math.max(...sessions.map(s => s.count));
+  const totalPushups = filtered.reduce((sum, session) => sum + session.count, 0);
+  const totalTime = filtered.reduce((sum, session) => sum + session.duration, 0);
+  const avgPerSession = filtered.length > 0 ? Math.round(totalPushups / filtered.length) : 0;
+  const bestSession = filtered.length > 0 ? Math.max(...filtered.map(s => s.count)) : 0;
   const avgTimePerRep = totalPushups > 0 ? totalTime / totalPushups : 0;
 
   // Prepare chart data (last 10 sessions)
-  const chartData = sessions.slice(0, 10).reverse().map((session, index) => ({
+  const chartData = filtered.slice(0, 10).reverse().map((session, index) => ({
     session: `#${index + 1}`,
     count: session.count,
     duration: session.duration,
@@ -40,7 +43,7 @@ export const StatsDisplay: React.FC<StatsDisplayProps> = ({ sessions }) => {
   }));
 
   // Weekly progress
-  const weeklyData = sessions.reduce((acc, session) => {
+  const weeklyData = filtered.reduce((acc, session) => {
     const week = getWeekString(session.date);
     if (!acc[week]) {
       acc[week] = { week, count: 0, sessions: 0 };
@@ -60,6 +63,9 @@ export const StatsDisplay: React.FC<StatsDisplayProps> = ({ sessions }) => {
 
   return (
     <div className="space-y-6">
+      <h2 className="text-xl font-semibold">
+        {exercise === 'pushup' ? 'Liegestütze' : 'Kniebeugen'}
+      </h2>
       {/* Key Statistics */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         <Card className="p-6 bg-gradient-to-br from-orange-400 to-orange-500 text-white">
@@ -86,7 +92,7 @@ export const StatsDisplay: React.FC<StatsDisplayProps> = ({ sessions }) => {
           <div className="flex items-center gap-3">
             <Clock className="h-8 w-8" />
             <div>
-              <p className="text-purple-100 text-sm">Ø Zeit/Liegestütze</p>
+              <p className="text-purple-100 text-sm">Ø Zeit/Wiederholung</p>
               <p className="text-2xl font-bold">{avgTimePerRep.toFixed(1)}s</p>
             </div>
           </div>
@@ -121,7 +127,7 @@ export const StatsDisplay: React.FC<StatsDisplayProps> = ({ sessions }) => {
               <Tooltip 
                 labelFormatter={(label) => `Session ${label}`}
                 formatter={(value, name) => [
-                  name === 'count' ? `${value} Liegestützen` : `${value}s`,
+                  name === 'count' ? `${value} Wiederholungen` : `${value}s`,
                   name === 'count' ? 'Anzahl' : 'Dauer'
                 ]}
               />
@@ -148,7 +154,7 @@ export const StatsDisplay: React.FC<StatsDisplayProps> = ({ sessions }) => {
               <YAxis />
               <Tooltip 
                 formatter={(value, name) => [
-                  `${value} ${name === 'count' ? 'Liegestützen' : 'Sessions'}`,
+                  `${value} ${name === 'count' ? 'Wiederholungen' : 'Sessions'}`,
                   name === 'count' ? 'Gesamt' : 'Sessions'
                 ]}
               />
@@ -178,7 +184,7 @@ export const StatsDisplay: React.FC<StatsDisplayProps> = ({ sessions }) => {
             <div className="flex justify-between items-center">
               <span className="text-gray-600">Beste Woche</span>
               <span className="font-semibold">
-                {weeklyChartData.length > 0 ? Math.max(...weeklyChartData.map(w => w.count)) : 0} Liegestützen
+                {weeklyChartData.length > 0 ? Math.max(...weeklyChartData.map(w => w.count)) : 0} Wiederholungen
               </span>
             </div>
           </div>
@@ -189,7 +195,7 @@ export const StatsDisplay: React.FC<StatsDisplayProps> = ({ sessions }) => {
           <div className="space-y-4">
             <div className="p-3 bg-blue-50 rounded-lg">
               <p className="text-sm font-medium text-blue-900">Nächstes Ziel</p>
-              <p className="text-blue-700">{bestSession + 5} Liegestützen in einer Session</p>
+              <p className="text-blue-700">{bestSession + 5} Wiederholungen in einer Session</p>
             </div>
             <div className="p-3 bg-green-50 rounded-lg">
               <p className="text-sm font-medium text-green-900">Empfehlung</p>

--- a/src/lib/SquatDetector.ts
+++ b/src/lib/SquatDetector.ts
@@ -1,0 +1,117 @@
+// Pose detection and squat counting logic
+import type {
+  Pose,
+  Results as PoseResults,
+  NormalizedLandmark,
+  NormalizedLandmarkList
+} from '@mediapipe/pose';
+
+export class SquatDetector {
+  private pose: Pose | null = null;
+  private initPromise: Promise<void>;
+  private isDown = false;
+  private count = 0;
+  private landmarks: PoseResults['poseLandmarks'] | null = null;
+  private isInitialized = false;
+
+  constructor() {
+    this.initPromise = this.initPose();
+  }
+
+  private async initPose() {
+    const mp = await import('@mediapipe/pose');
+    const PoseCtor: typeof Pose =
+      (mp as unknown as { Pose?: typeof Pose }).Pose ??
+      (mp as { default?: { Pose: typeof Pose } }).default?.Pose ??
+      (globalThis as unknown as { Pose?: typeof Pose }).Pose;
+    if (!PoseCtor) throw new Error('Failed to load Pose constructor');
+    this.pose = new PoseCtor({
+      locateFile: (f: string) => `https://cdn.jsdelivr.net/npm/@mediapipe/pose/${f}`
+    });
+    this.pose.setOptions({
+      modelComplexity: 0,
+      smoothLandmarks: true,
+      enableSegmentation: false,
+      selfieMode: false,
+    });
+    this.pose.onResults((results) => {
+      if (results.poseLandmarks) {
+        if (!this.isInitialized) this.isInitialized = true;
+        this.landmarks = results.poseLandmarks;
+        this.processLandmarks(results.poseLandmarks);
+      }
+    });
+  }
+
+  async detect(video: HTMLVideoElement): Promise<number> {
+    await this.initPromise;
+    if (!this.pose) return this.count;
+    if (!this.isInitialized) {
+      await this.pose.send({ image: video });
+      return this.count;
+    }
+    await this.pose.send({ image: video });
+    return this.count;
+  }
+
+  private angle(a: NormalizedLandmark, b: NormalizedLandmark, c: NormalizedLandmark) {
+    const ab = { x: a.x - b.x, y: a.y - b.y };
+    const cb = { x: c.x - b.x, y: c.y - b.y };
+    const dot = ab.x * cb.x + ab.y * cb.y;
+    const magAB = Math.hypot(ab.x, ab.y);
+    const magCB = Math.hypot(cb.x, cb.y);
+    return (Math.acos(dot / (magAB * magCB)) * 180) / Math.PI;
+  }
+
+  private processLandmarks(l: NormalizedLandmarkList) {
+    const leftHip = l[23];
+    const rightHip = l[24];
+    const leftKnee = l[25];
+    const rightKnee = l[26];
+    const leftAnkle = l[27];
+    const rightAnkle = l[28];
+
+    if (!leftHip || !rightHip || !leftKnee || !rightKnee || !leftAnkle || !rightAnkle) {
+      return;
+    }
+
+    const leftAngle = this.angle(leftHip, leftKnee, leftAnkle);
+    const rightAngle = this.angle(rightHip, rightKnee, rightAnkle);
+    const avg = (leftAngle + rightAngle) / 2;
+
+    if (avg < 100 && !this.isDown) {
+      this.isDown = true;
+    }
+
+    if (avg > 160 && this.isDown) {
+      this.isDown = false;
+      this.count++;
+    }
+  }
+
+  reset() {
+    this.count = 0;
+    this.isDown = false;
+    this.landmarks = null;
+  }
+
+  getCount() {
+    return this.count;
+  }
+
+  getLandmarks() {
+    return this.landmarks;
+  }
+
+  isReady() {
+    return this.isInitialized;
+  }
+
+  cleanup() {
+    if (this.pose) {
+      this.pose.reset();
+    }
+  }
+}
+
+export type { PoseResults };


### PR DESCRIPTION
## Summary
- add `SquatDetector` for knee bend detection
- track both pushups and squats in `PushupTracker`
- record exercise type in session handling
- show separate counters in tracker and quick stats
- expose per‑exercise stats and highscores

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68441bf4bc8c832da1f74fa2abf9625c