### PR TITLE
Fix username assignment in highscores

### DIFF
--- a/src/lib/community.ts
+++ b/src/lib/community.ts
@@ -247,12 +247,17 @@ export async function fetchHighscores(
       let totalCount = 0;
 
       local.forEach(r => {
-        const name = r.username?.trim() || r.email || 'Unbekannt';
-        const key = name.toLowerCase();
+        const username = r.username?.trim() || undefined;
+        const key = (r.user_id || username || r.email || 'unknown').toLowerCase();
+        const displayName = username || r.email || 'Unbekannt';
         totalCount += r.count;
         const existing = totals.get(key);
-        if (existing) existing.count += r.count;
-        else totals.set(key, { name, count: r.count });
+        if (existing) {
+          existing.count += r.count;
+          if (username) existing.name = username;
+        } else {
+          totals.set(key, { name: displayName, count: r.count });
+        }
       });
 
       const scores = Array.from(totals.values())
@@ -266,16 +271,22 @@ export async function fetchHighscores(
   let totalCount = 0;
 
   (data || []).forEach(r => {
-    const name =
+    const uid = (r as Record<string, unknown>).user_id as string | undefined;
+    const username =
       typeof r.username === 'string' && r.username.trim()
         ? r.username.trim()
-        : 'Unbekannt';
+        : undefined;
 
-    const key = name.toLowerCase();
+    const key = (uid || username || 'unknown').toLowerCase();
+    const displayName = username || 'Unbekannt';
     totalCount += r.count as number;
     const existing = totals.get(key);
-    if (existing) existing.count += r.count as number;
-    else totals.set(key, { name, count: r.count as number });
+    if (existing) {
+      existing.count += r.count as number;
+      if (username) existing.name = username;
+    } else {
+      totals.set(key, { name: displayName, count: r.count as number });
+    }
   });
 
   const scores = Array.from(totals.values())


### PR DESCRIPTION
## Summary
- ensure local session aggregation uses user_id when available
- aggregate server highscores by user_id to keep names consistent

## Testing
- `npm run lint`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_685400c707f0832d8644df0b1fe04813